### PR TITLE
Link do MeetUp de SP

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Estado                  | Meetup Link                               | Organizado
 <img src="resources/bandeiras/rio-grande-do-norte.png" width=16/> **Rio Grande do Norte** | [meetup.com/Ionic-Rio-Grande-do-Norte][mRN]  | @andypcastro
 <img src="resources/bandeiras/rio-grande-do-sul.png" width=16/> **Rio Grande do Sul** | [meetup.com/Ionic-Rio-Grande-do-Sul][mRS] | @silvamarcel @arthuralv3s
 <img src="resources/bandeiras/santa-catarina.png" width=16/> **Santa Catarina**  | [meetup.com/Ionic-Santa-Catarina][mSC]  | @rgazeredo @giiorgio_
-<img src="resources/bandeiras/sao-paulo.png" width=16/> **São Paulo**  | [meetup.com/IonicSaoPaulo][mSP]  | @felquis @lucasbastianik
+<img src="resources/bandeiras/sao-paulo.png" width=16/> **São Paulo**  | [meetup.com/pt/Sao-Paulo-Ionic-Framework-Meetup][mSP]  | Livio Alves
 
 [mAL]: http://meetup.com/Ionic-Alagoas
 [mBH]: http://meetup.com/Ionic-Bahia


### PR DESCRIPTION
O link antigo apontava para um grupo que não existe.
"O Meetup que você está buscando não existe"

Sugiro atualizar para este existente ou criarem um novo para São Paulo.
